### PR TITLE
feat(docs): navigate with left/right arrow keys

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,7 +85,8 @@ html_theme = 'sphinx_rtd_theme'
 # documentation.
 #
 html_theme_options = {
-    'analytics_id': 'UA-83738774-2'
+    'analytics_id': 'UA-83738774-2',
+    'navigation_with_keys': True
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Enables docs navigation with left/right arrow keys. It can be useful for the ones who navigate with keyboard a lot.
More info : https://github.com/sphinx-doc/sphinx/pull/2064
